### PR TITLE
Update serving_requirements.txt for Aarch64

### DIFF
--- a/serving_requirements.txt
+++ b/serving_requirements.txt
@@ -328,7 +328,7 @@ markupsafe==2.1.2 ; python_version >= "3.9" and python_version < "3.11" \
     --hash=sha256:f1cd098434e83e656abf198f103a8207a8187c0fc110306691a2e94a78d0abb2 \
     --hash=sha256:f2bfb563d0211ce16b63c7cb9395d2c682a23187f54c3d79bfec33e6705473c6 \
     --hash=sha256:f8ffb705ffcf5ddd0e80b65ddf7bed7ee4f5a441ea7d3419e861a12eaf41af58
-numpy==1.23.5 ; python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64" \
+numpy==1.23.5 ; python_version >= "3.9" and python_version < "3.11" and platform_machine == "aarch64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64" \
     --hash=sha256:01dd17cbb340bf0fc23981e52e1d18a9d4050792e8fb8363cecbf066a84b827d \
     --hash=sha256:06005a2ef6014e9956c09ba07654f9837d9e26696a0470e42beedadb78c11b07 \
     --hash=sha256:09b7847f7e83ca37c6e627682f145856de331049013853f344f37b0c9690e3df \
@@ -425,7 +425,7 @@ setuptools==67.6.0 ; python_version >= "3.9" and python_version < "3.11" \
 six==1.16.0 ; python_version >= "3.9" and python_version < "3.11" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-tflite-runtime==2.11.0 ; python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64" \
+tflite-runtime==2.11.0 ; python_version >= "3.9" and python_version < "3.11" and platform_machine == "aarch64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64" \
     --hash=sha256:086f5ac54e6b6a73b75fa91ea63a7c8a71274272c787f39ed1ebeab2d570595c \
     --hash=sha256:1cf50a6c51147d70299f4469f6cfab732f38f6ee7999df287155513e742360e6 \
     --hash=sha256:50832befa76d69de082394716846e12d85fa8257f3ddb0a4755479bdb0a47083 \


### PR DESCRIPTION
numpy and tflite-runtime were ignored when running `pip install --no-cache-dir -r requirements.txt`, probably because platform_machine returns 'aarch64' on my machine.
```
Ignoring numpy: markers 'python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64"' don't match your environment
Ignoring tflite-runtime: markers 'python_version >= "3.9" and python_version < "3.11" and platform_machine == "arm64" or python_version >= "3.9" and python_version < "3.11" and platform_machine == "x86_64"' don't match your environment
```
This patch gets around the problem by explicitly listing the requirement, no idea if this is the correct fix but the packages are now correctly installed.